### PR TITLE
Migrate to logos 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,5 @@ repository = "https://github.com/JesterOrNot/SynTerm"
 readme = "README.md"
 
 [dependencies]
-crossterm = "0.16.0"
-termion = "1.5.5"
-logos = "0.9.7"
+crossterm = "0.17.3"
+logos = "0.11"

--- a/examples/color_prompt.rs
+++ b/examples/color_prompt.rs
@@ -18,6 +18,7 @@ impl CommandLineTool for MyTool {
             TheLexer,
             parser,
             (Red, Color::Red, "red"),
+            (Keyword, Color::Yellow, "exit"),
             (Green, Color::Green, "green"),
             (Blue, Color::Blue, "blue"),
             (NoHighlight, Color::White, "[a-zA-Z0-9_$]+")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use crossterm::{
     event::{read, Event, KeyCode, KeyModifiers},
     terminal::{disable_raw_mode, enable_raw_mode},
-    tty::IsTty
+    tty::IsTty,
 };
 use std::{
     fmt,
@@ -188,16 +188,14 @@ pub trait CommandLineTool {
                         modifiers: z,
                     } => match m {
                         KeyCode::Char(v) => match z {
-                            KeyModifiers::CONTROL => {
-                                match v {
-                                    'd' => {
-                                        disable_raw_mode().unwrap();
-                                        println!();
-                                        exit(0);
-                                    }
-                                    _ => {}
+                            KeyModifiers::CONTROL => match v {
+                                'd' => {
+                                    disable_raw_mode().unwrap();
+                                    println!();
+                                    exit(0);
                                 }
-                            }
+                                _ => {}
+                            },
                             _ => {
                                 buffer.insert(cursor_position, v);
                                 cursor_position += 1;


### PR DESCRIPTION
* Update crossterm
* Fix control keys clearing buffer bug
* Remove termion and replace it with crossterm's is_tty function

<a href="https://gitpod.io/#https://github.com/JesterOrNot/SynTerm/pull/7"><img src="https://gitpod.io/api/apps/github/pbs/github.com/JesterOrNot/SynTerm.git/9cc8b71db1a08935a6615d8037690e209b268452.svg" /></a>

